### PR TITLE
feat(websites): add 'last_check_at' field to graphql and UI components

### DIFF
--- a/changescout/internal/api/gql/schema/website.graphqls
+++ b/changescout/internal/api/gql/schema/website.graphqls
@@ -18,6 +18,7 @@ type Website {
     enabled: Boolean!
     mode: Mode!
     next_check_at: Time!
+    last_check_at: Time
     cron: CronExpression!
     setting: Setting
 }

--- a/web/schemal.graphql
+++ b/web/schemal.graphql
@@ -119,6 +119,7 @@ type Website {
   enabled: Boolean!
   mode: Mode!
   next_check_at: Time!
+  last_check_at: Time
   cron: CronExpression!
   setting: Setting
 }

--- a/web/src/components/websites/WebsiteList.tsx
+++ b/web/src/components/websites/WebsiteList.tsx
@@ -63,6 +63,9 @@ export function WebsiteList() {
                   </h3>
                   <p className="mt-1 text-sm text-gray-500">{website.url}</p>
                   <p className="mt-1 text-xs text-gray-400">
+                    Last check: {website.last_check_at ? new Date(website.last_check_at).toLocaleString() : 'N/A'}
+                  </p>
+                  <p className="mt-1 text-xs text-gray-400">
                     Next check: {new Date(website.next_check_at).toLocaleString()}
                   </p>
                 </Link>

--- a/web/src/lib/graphql/websites.ts
+++ b/web/src/lib/graphql/websites.ts
@@ -9,6 +9,7 @@ export const GET_WEBSITE_BY_ID = gql`query GetWebsiteByID($id: ID!) {
     enabled
     mode
     next_check_at
+    last_check_at
     cron
     setting {
       user_agent
@@ -31,6 +32,7 @@ export const GET_WEBSITE_BY_URL = gql`query GetWebsiteByURL($url: String!) {
     enabled
     mode
     next_check_at
+    last_check_at
     cron
     setting {
       user_agent
@@ -53,6 +55,7 @@ export const GET_WEBSITES = gql`query GetWebsites {
     enabled
     mode
     next_check_at
+    last_check_at
     cron
     setting {
       user_agent
@@ -75,6 +78,7 @@ export const CREATE_WEBSITE = gql`mutation CreateWebsite($input: WebsiteCreateIn
     enabled
     mode
     next_check_at
+    last_check_at
     cron
     setting {
       user_agent
@@ -97,6 +101,7 @@ export const UPDATE_WEBSITE = gql`mutation UpdateWebsite($input: WebsiteUpdateIn
     enabled
     mode
     next_check_at
+    last_check_at
     cron
     setting {
       user_agent
@@ -119,6 +124,7 @@ export const CHANGE_WEBSITE_STATUS = gql`mutation ChangeWebsiteStatus($id: ID!, 
     enabled
     mode
     next_check_at
+    last_check_at
     cron
     setting {
       user_agent

--- a/web/src/pages/websites/WebsiteDetailPage.tsx
+++ b/web/src/pages/websites/WebsiteDetailPage.tsx
@@ -127,6 +127,12 @@ export function WebsiteDetailPage() {
                 })()}
               </p>
             </div>
+            <div>
+              <label className="text-sm font-medium text-gray-500">Last Check</label>
+              <p className="text-gray-900">
+                {website.last_check_at ? new Date(website.last_check_at).toLocaleString() : 'N/A'}
+              </p>
+            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
This commit introduces a new 'last_check_at' field to the GraphQL schema and updates various UI components to display this information. The pages updated include WebsiteList and WebsiteDetailPage, providing users with the last check timestamp for each website.