### PR TITLE
refactor(notification): update diff handling to use structured change…

### DIFF
--- a/changescout/internal/app/services/diff/diff.go
+++ b/changescout/internal/app/services/diff/diff.go
@@ -121,27 +121,21 @@ func (s *Service) compareText(previous, current []byte) (Result, error) {
 			}
 			switch diff.Type {
 			case diffmatchpatch.DiffInsert:
-				buf.WriteString("+ ")
 				buf.WriteString(line)
-				buf.WriteString("\n")
 				changes = append(changes, Change{
 					Type:    Added,
 					Content: diff.Text,
 				})
 				changedLen += float64(len(diff.Text))
 			case diffmatchpatch.DiffDelete:
-				buf.WriteString("- ")
 				buf.WriteString(line)
-				buf.WriteString("\n")
 				changes = append(changes, Change{
 					Type:    Removed,
 					Content: diff.Text,
 				})
 				changedLen += float64(len(diff.Text))
 			case diffmatchpatch.DiffEqual:
-				buf.WriteString("  ")
 				buf.WriteString(line)
-				buf.WriteString("\n")
 			}
 		}
 	}
@@ -215,7 +209,6 @@ func (s *Service) renderHTMLDiff(buf *strings.Builder, indent string, node1, nod
 	}
 
 	if node1 == nil {
-		buf.WriteString("+ ")
 		buf.WriteString(indent)
 		buf.WriteString(s.formatNode(node2))
 		buf.WriteString("\n")

--- a/changescout/internal/pkg/templates/diff-default-message.tpl
+++ b/changescout/internal/pkg/templates/diff-default-message.tpl
@@ -1,10 +1,3 @@
-*Website:* {{.Name}}
-*Mode*: {{.Mode}}
-
-*Details:*
-- URL: {{.URL}}
-- Last Checked: {{.LastChecked}}
-- Diff:
-```diff
-{{.Diff}}
-```
+🌐 {{.Name}} ({{.Mode}})
+🔗 {{.URL}} | ⏱ {{.LastChecked}} {{"\n"}}
+{{- range .Result.Changes }} ({{.Type }}): {{.Content}}{{"\n"}}{{- end }}


### PR DESCRIPTION
Simplified and modernized message templates and diff rendering by replacing raw diff strings with structured `diff.Result`. Updated tests and notification logic accordingly.